### PR TITLE
Update payments API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tigerbay",
-  "version": "1.2.0-beta.1",
+  "version": "2.0.0-beta.1",
   "description": "API Client library for TigerBay",
   "main": "lib/client.js",
   "type": "commonjs",

--- a/src/models/payments.ts
+++ b/src/models/payments.ts
@@ -13,6 +13,7 @@ export interface CreatePaymentRequest {
     Amount?: PaymentAmount
     AuthorisationCode?: string
     TransactionReference?: string
+    Reference?: string
     Token?: string
     Last4Digits?: string
     Status?: PaymentStatus

--- a/src/models/payments.ts
+++ b/src/models/payments.ts
@@ -1,38 +1,22 @@
 import { APIGroup, LinkedObject } from "./common";
-import { Price } from "./reservations";
 
+export type PaymentStatus = 'Failed' | 'Authorised' | 'Pending' | 'Complete' |
+                            'UserCancelled' | 'Initialised'
+
+export type PaymentProvider = 'NotSet' | 'GlobalPayments' | 'Opayo' | 'Test' | 'Syntec' | 'DataCash'
 
 /**
  * Parameters to create a new payment
  */
 export interface CreatePaymentRequest {
-    Amount: PaymentAmount
-
-    AuthorizationCode?: string
-
+    TypeId?: number
+    Amount?: PaymentAmount
+    AuthorisationCode?: string
+    TransactionReference?: string
+    Token?: string
     Last4Digits?: string
-    Status?: "Completed" | "Pending" | "Failed" | "Authorised"
-
-    /**
-     * An optional payment reference
-     */
-    Reference?: string
-
-    /**
-     * URL to return the user to after making the payment
-     */
-    ReturnUrl?: string
-
-    /**
-     * ID of the customer contact to associate the payment with
-     */
-    ContactIdForPayment: number
-
-    /**
-     * Payment Type ID
-     */
-    SetupPaymentTypeId: number
-
+    Status?: PaymentStatus
+    Provider?: PaymentProvider
     ProviderData: Array<{key: string, value: string}>
 }
 
@@ -41,30 +25,31 @@ export interface PaymentAmount {
     Value: number
 }
 
-export interface CreatePaymentResponse extends LinkedObject {
+export interface PaymentType {
     Id: number
-    ReservationId: number
-    Url: string
-    Message: string
+    Name?: string
+    PaymentMethod?: 'Manual' | 'PaymentProvider'
 }
 
-export interface Payment extends CreatePaymentResponse {
-    Status: string
-    Reference: string
-    SetupPaymentCardId: number
-    CreatedDate: Date
-    CompletedDate: Date
-    Amount: Price
-    Charge: Price
-    Total: Price
-    CreatedByUserId: number
-    OwnerUserId: number
-    ParentID: number
-    PaymentProviderReference?: string
-    PaymentTypeReference?: string
-    Token?: string
+export interface Payment extends LinkedObject {
+    Id: number
+    CreatedDateTime: string
+    CreatedBy?: { Id?: number }
+    Type?: PaymentType
+    PaymentAmount: PaymentAmount
+    AuthorisationCode?: string
     TransactionReference?: string
     Last4Digits?: string
+    Status?: PaymentStatus
+    ProviderData?: Array<{key: string, value: string}>
+    Provider?: PaymentProvider
+    Reference?: string
+    CompletedDate?: string
+    IsScheduled?: boolean
+    ScheduledDate?: string
+    IsScheduledPrincipal?: boolean
+    IsScheduledPrincipalCandidate?: boolean
+    IsScheduledFinal?: boolean
 }
 
 /**
@@ -78,12 +63,28 @@ export class Api extends APIGroup {
      * @param reservationId ID of the reservation to add the payment to
      * @param payment Paramters for the payment
      */
-    public async create(reservationId: number, payment: CreatePaymentRequest): Promise<CreatePaymentResponse> {
-        return (await this.axios.post(`/sales/reservations/${reservationId}/payments`, payment)).data
+    public async create(reservationId: number, payment: CreatePaymentRequest): Promise<Payment> {
+        return (await this.axios.post(`/3/sales/reservations/${reservationId}/payments`, payment)).data
     }
 
+    /**
+     * 
+     * @param reservationId Reservation ID within which to find the payment
+     * @param id ID of the payment to find
+     * @returns {Promise<Payment>} Payment details
+     */
     public async find(reservationId: number, id: number): Promise<Payment> {
-        return (await this.axios.get<Payment>(`/sales/reservations/${reservationId}/payments/${id}`)).data
+        return (await this.axios.get<Payment>(`/3/sales/reservations/${reservationId}/payments/${id}`)).data
+    }
+
+    /**
+     * List Payments by Reservation
+     * 
+     * @param reservationId ID of Reservation to list payments for
+     * @returns {Promise<Payment[]>} List of payments made against the reservation
+     */
+    public async list(reservationId: number): Promise<Payment[]> {
+        return (await this.axios.get<Payment[]>(`/3/sales/reservations/${reservationId}/payments`)).data
     }
 
     /**
@@ -91,6 +92,8 @@ export class Api extends APIGroup {
      * 
      * @param reservationId ID of the reservation the payment is against
      * @param paymentId ID of the payment to finalize
+     * 
+     * @deprecated
      */
     public async finalize(reservationId: number, paymentId: string): Promise<Payment> {
         return (await this.axios.post(`/sales/reservations/${reservationId}/payments/${paymentId}/completionRequest`)).data


### PR DESCRIPTION
Updates the payments API endpoint to the latest version based on TigerBay's published documentation.

> [!WARNING]
> This change is *incompatible* with previous versions. Some parameter names have changed between v1 and v3 of this method.

The following parameter names have been changed:

* `Reference` -> `TransactionReference`
* `SetupPaymentTypeId` -> `TypeId`

The following parameters have been removed:

* `ReturnURL`
* `ContactIDForPayment`
* `ParentID`

Additional changes are noted to the `Payment` model too.